### PR TITLE
Add GLPK solver

### DIFF
--- a/src/MathProgBase.jl
+++ b/src/MathProgBase.jl
@@ -1,4 +1,15 @@
 module MathProgBase
+
+    if Pkg.installed("Clp") != nothing
+        @eval import Clp
+    end
+    if Pkg.installed("CoinMP") != nothing
+        @eval import CoinMP
+    end
+    if Pkg.installed("GLPKMathProgInterface") != nothing
+        @eval using GLPKMathProgInterface
+    end
+
     require(joinpath(Pkg.dir("MathProgBase"),"src","LinprogSolverInterface.jl"))
     using LinprogSolverInterface
     include("linprog.jl")

--- a/src/linprog.jl
+++ b/src/linprog.jl
@@ -1,13 +1,23 @@
 
-using LinprogSolverInterface
-
 if Pkg.installed("Clp") != nothing
-    @eval using Clp
     lpsolver = Clp
+elseif Pkg.installed("GLPKMathProgInterface") != nothing
+    lpsolver = GLPKInterfaceLP
 else
     lpsolver = nothing
 end
 setlpsolver(s) = (global lpsolver; lpsolver = s)
+function setlpsolver(s::Symbol)
+    global lpsolver
+    if s == :Clp
+        lpsolver = Clp
+    elseif s == :GLPK
+        lpsolver = GLPKInterfaceLP
+    else
+        error("Unrecognized LP solver name $s")
+    end
+end
+
 
 type LinprogSolution
     status
@@ -33,7 +43,9 @@ end
 
 function linprog(c::InputVector, A::AbstractMatrix, rowlb::InputVector, rowub::InputVector, lb::InputVector, ub::InputVector; options...)
     if lpsolver == nothing
-        error("No LP solver installed. Please run Pkg.add(\"Clp\") and reload MathProgBase")
+        error("No LP solver installed. " *
+              "Please run Pkg.add(\"Clp\") or Pkg.add(\"GLPKMathProgInterface\") " *
+              "and reload MathProgBase")
     end
     m = lpsolver.model(;options...)
     nrow,ncol = size(A)

--- a/src/mixintprog.jl
+++ b/src/mixintprog.jl
@@ -1,11 +1,22 @@
 
 if Pkg.installed("CoinMP") != nothing
-    @eval using CoinMP
     mipsolver = CoinMP
+elseif Pkg.installed("GLPKMathProgInterface") != nothing
+    mipsolver = GLPKInterfaceMIP
 else
     mipsolver = nothing
 end
 setmipsolver(s) = (global mipsolver; mipsolver = s)
+function setmipsolver(s::Symbol)
+    global mipsolver
+    if s == :CoinMP
+        mipsolver = CoinMP
+    elseif s == :GLPK
+        mipsolver = GLPKInterfaceMIP
+    else
+        error("Unrecognized MIP solver name $s")
+    end
+end
 
 type MixintprogSolution
     status
@@ -18,7 +29,9 @@ typealias CharInputVector Union(Vector{Char},Real)
 
 function mixintprog(c::InputVector, A::AbstractMatrix, rowlb::InputVector, rowub::InputVector, vartypes::CharInputVector, lb::InputVector, ub::InputVector; options...)
     if mipsolver == nothing
-        error("No MIP solver installed. Please run Pkg.add(\"CoinMP\") and reload MathProgBase")
+        error("No MIP solver installed. " *
+              "Please run Pkg.add(\"CoinMP\") or Pkg.add(\"GLPKMathProgInterface\") " *
+              "and reload MathProgBase")
     end
     m = mipsolver.model(;options...)
     nrow,ncol = size(A)


### PR DESCRIPTION
I just pushed the GLPKSolverInterface.jl package to METADATA. With this patch, MathProgBase can use it. The default is still Clp.
