### PR TITLE
proposed revision of conic interface

### DIFF
--- a/doc/conic.rst
+++ b/doc/conic.rst
@@ -12,15 +12,15 @@ We consider the following primal problem to be in canonical conic form:
 
 .. math::
     \min_{x}\, &c^Tx\\
-    s.t.\,   &Ax - b \in K_1\\
+    s.t.\,   &b - Ax \in K_1\\
              &x \in K_2\\
 
 where :math:`K_1` and :math:`K_2` are cones (likely a product of a number of cones),
 with corresponding dual
 
 .. math::
-    \max_y\, &b^Ty\\
-    s.t.\,   &c - A^Ty \in K_2^*\\
+    \max_y\, &-b^Ty\\
+    s.t.\,   &c + A^Ty \in K_2^*\\
              &y \in K_1^*
 
 where :math:`K_1^*` and :math:`K_2^*` are the dual cones of :math:`K_1` and :math:`K_2`, respectively.


### PR DESCRIPTION
As discussed in #36, here's a proposed revision to the conic interface which allows the user to specify conic restrictions on both variables and affine functions of variables. Solver interfaces will be responsible for massaging the problem into the format required by each solver, but this interface makes it easier on the modeling side by avoiding the need for slacks and identity transformations.

The primal is:

```
min c'x
s.t. Ax - b in K_1
     x in K_2
```

and the dual is:

```
max b'y
s.t.   c - A'y in K_2^*
       y in K_1^*
```

The choice of signs for the affine constraints is arbitrary but results in a dual that's reasonably aesthetically pleasing to me (negative signs in the objective seem ugly). 

Here's a preview of the docs: http://mathprogbasejl.readthedocs.org/en/conic2/conic.html

@madeleineudell @karanveerm @IainNZ @joehuchette 
