### PR TITLE
supportedcones method

### DIFF
--- a/doc/conic.rst
+++ b/doc/conic.rst
@@ -66,5 +66,9 @@ Not all solvers are expected to support all types of cones. However, when a simp
 
     If the solve was successful, returns the optimal dual solution vector :math:`y`.
 
+.. function:: supportedcones(m::AbstractMathProgSolver)
+
+    Returns a list of cones supported by the solver.
+
 The solution vector, optimal objective value, termination status, etc. should be accessible from the standard methods, e.g., ``getsolution``, ``getobjval``, ``status``, respectively.
     


### PR DESCRIPTION
For the conic interface, adds a method to query which cones are supported by a solver. This takes in an `AbstractMathProgSolver` object. Example usage:

```
julia> MathProgBase.supportedcones(CplexSolver())
5-element Array{Symbol,1}:
 :Free  
 :Zero  
 :NonNeg
 :NonPos
 :SOC
```

It's not 100% clear if this should be a method for `AbstractMathProgSolver` or `AbstractMathProgModel` (or both).

Ref JuliaOpt/JuMP.jl#83

@karanveerm @madeleineudell @IainNZ @joehuchette 
