### PR TITLE
Change getmipgap to getobjgap

### DIFF
--- a/src/MathProgSolverInterface.jl
+++ b/src/MathProgSolverInterface.jl
@@ -44,7 +44,7 @@ module MathProgSolverInterface
           getsimplexiter,
           getbarrieriter,
           getnodecount,
-          getmipgap,
+          getobjgap,
           getobjbound,
           initialize,
           features_available,


### PR DESCRIPTION
getmipgap only appears at `MathProgSolverInterface`. From the description, it seems that getobjgap is the correct name.