### PR TITLE
Add suggestion to try Pkg.build to warning

### DIFF
--- a/src/defaultsolvers.jl
+++ b/src/defaultsolvers.jl
@@ -45,7 +45,8 @@ for solvertype in ["LP", "MIP", "QP", "SDP", "NLP", "Conic"]
                 try
                     eval(Expr(:import,pkgname))
                 catch
-                    warn("Package ",string(pkgname)," is installed but couldn't be loaded")
+                    warn("Package ",string(pkgname)," is installed but couldn't be loaded. ",
+                        "You may need to run `Pkg.build(\"$pkgname\")`")
                 end
                 ex = Expr(:(=), $(quot(defaultname)), Expr(:call,Expr(:.,pkgname,quot(solvername))))
                 eval(ex)


### PR DESCRIPTION
ref https://groups.google.com/forum/#!topic/julia-opt/0qarF_DA_28

And it looks like at least `Pkg.build("Clp")` should result in Cbc's BinDeps script getting run, and hopefully more of an error message for anyone having trouble.