### PR TITLE
Add Ipopt as a default QP solver

### DIFF
--- a/src/defaultsolvers.jl
+++ b/src/defaultsolvers.jl
@@ -15,7 +15,8 @@ const MIPsolvers = [(:Cbc,:CbcSolver),
      
 const QPsolvers = [(:Gurobi,:GurobiSolver),
                    (:CPLEX,:CplexSolver),
-                   (:Mosek,:MosekSolver)]
+                   (:Mosek,:MosekSolver),
+                   (:Ipopt,:IpoptSolver)]
 
 const SDPsolvers = [(:Mosek,:MosekSolver)]
 


### PR DESCRIPTION
ref https://github.com/JuliaLang/JuliaBox/issues/230

We can replace this with something more specific if we get an open-source QP solver hooked into MathProgBase, but for now is there any downside to this? Always typing `IpoptSolver` is getting a little old :)
