### PR TITLE
freemodel! method

### DIFF
--- a/doc/lowlevel.rst
+++ b/doc/lowlevel.rst
@@ -105,7 +105,14 @@ to indicate equality constraints.
     coefficients, and the ``varidx`` vector contains the indices of the corresponding
     variables.
 
+.. function:: freemodel!(m::AbstractMathProgModel)
 
+    Release any resources and memory used by the model. Note that the
+    Julia garbage collector takes care of this automatically, but
+    automatic collection cannot always be forced. This method is useful for more
+    precise control of resources, especially in the case of commercial solvers
+    with licensing restrictions on the number of concurrent runs.
+    Users must discard the model object after this method is invoked.
 
 .. function:: updatemodel!(m::AbstractMathProgModel)
 

--- a/src/SolverInterface/SolverInterface.jl
+++ b/src/SolverInterface/SolverInterface.jl
@@ -32,6 +32,7 @@ export AbstractMathProgSolver
     loadproblem!
     writeproblem
     updatemodel!
+    freemodel!
     optimize!
 end
 


### PR DESCRIPTION
The julia garbage collector isn't great for managing when resources are released. This is a problem when dealing with commercial solvers that have a limit on the number of concurrent runs. Here's a method that gives the user more control over when a model is freed. Once this is set up and implemented we can expose it through JuMP.

CC @emreyamangil @philipithomas @IainNZ @joehuchette 