### PR TITLE
implement tagging system for SolverInterface methods

### DIFF
--- a/src/SolverInterface/LinearQuadratic.jl
+++ b/src/SolverInterface/LinearQuadratic.jl
@@ -38,9 +38,9 @@ export AbstractLinearQuadraticModel
     getvartype
     getinfeasibilityray
     getunboundedray
-    getsimplexiter
-    getbarrieriter
-    getnodecount
+    getsimplexiter, rewrap
+    getbarrieriter, rewrap
+    getnodecount, rewrap
     getbasis
 end
 

--- a/src/SolverInterface/lpqp_to_conic.jl
+++ b/src/SolverInterface/lpqp_to_conic.jl
@@ -184,8 +184,12 @@ function loadproblem!(m::LPQPtoConicBridge, c, A, b, constr_cones, var_cones)
     end
 end
 
-for f in [:optimize!, :status, :getsolution, :getobjval, :getreducedcosts, :getvartype]
+for f in [:optimize!, :status, :getsolution, :getobjval, :getvartype]
     @eval $f(model::LPQPtoConicBridge) = $f(model.lpqpmodel)
 end
 
 setvartype!(model::LPQPtoConicBridge, vtype) = setvartype!(model.lpqpmodel, vtype)
+
+for f in methods_by_tag[:rewrap]
+    @eval $f(model::LPQPtoConicBridge) = $f(model.lpqpmodel)
+end


### PR DESCRIPTION
Closes https://github.com/JuliaOpt/MathProgBase.jl/issues/96 and should make it easier to rewrap some of the basic access methods from JuMP.

CC @joehuchette @IainNZ 