### PR TITLE
support for _local_ lazy constraints and user cuts (cplex)

### DIFF
--- a/doc/lpqcqp.rst
+++ b/doc/lpqcqp.rst
@@ -290,9 +290,17 @@ If a callback function returns ``:Exit``, the solver is expected to terminate wi
 
    Adds cut to model. The coefficient values are represented sparsely, with (one-indexed) indices in ``varidx`` and values in ``varcoef``. The constraint sense ``sense`` is a character taking value ``<``, ``>``, or ``=``, and the right-hand side value is ``rhs``.
 
+.. function:: cbaddcutlocal!(d::MathProgCallbackData,varidx,varcoef,sense,rhs)
+
+   Adds local cut to model. It works as ``cbaddcut!`` but the cut is local in the sense that it only applies to the current node and the subtree rooted at this node.
+
 .. function:: cbaddlazy!(d::MathProgCallbackData,varidx,varcoef,sense,rhs)
 
    Adds lazy constraint to model. The coefficient values are represented sparsely, with (one-indexed) indices in ``varidx`` and values in ``varcoef``. The constraint sense ``sense`` is a character taking value ``<``, ``>``, or ``=``, and the right-hand side value is ``rhs``.
+ 
+ .. function:: cbaddlazylocal!(d::MathProgCallbackData,varidx,varcoef,sense,rhs)
+
+   Adds local lazy constraint to model. It works as ``cbaddlazy!`` but the lazy constraint is local in the sense that it only applies to the current node and the subtree rooted at this node.
 
 .. function:: cbaddsolution!(d::MathProgCallbackData)
 

--- a/doc/lpqcqp.rst
+++ b/doc/lpqcqp.rst
@@ -298,7 +298,7 @@ If a callback function returns ``:Exit``, the solver is expected to terminate wi
 
    Adds lazy constraint to model. The coefficient values are represented sparsely, with (one-indexed) indices in ``varidx`` and values in ``varcoef``. The constraint sense ``sense`` is a character taking value ``<``, ``>``, or ``=``, and the right-hand side value is ``rhs``.
  
- .. function:: cbaddlazylocal!(d::MathProgCallbackData,varidx,varcoef,sense,rhs)
+.. function:: cbaddlazylocal!(d::MathProgCallbackData,varidx,varcoef,sense,rhs)
 
    Adds local lazy constraint to model. It works as ``cbaddlazy!`` but the lazy constraint is local in the sense that it only applies to the current node and the subtree rooted at this node.
 

--- a/src/SolverInterface/callbacks.jl
+++ b/src/SolverInterface/callbacks.jl
@@ -16,8 +16,9 @@ export MathProgCallbackData
     cbgetexplorednodes
     cbgetstate
     cbaddcut!
+    cbaddcutlocal!
     cbaddlazy!
+    cbaddlazylocal!
     cbaddsolution!
     cbsetsolutionvalue!
 end
-


### PR DESCRIPTION
First, thanks a lot for all these wonderful and truely useful tools!

Having re-coded some algorithm using _local_ lazy constraints* with Julia/JuMP, here is a suggestion of very small additions handling them in JuMP/MathProgBase/CPLEX (joint additions, cf the forks at https://github.com/madanim). As far as I know, this feature is only avalaible in CPLEX and XPress MP.

It simply consists in duplicating the current mechanics for lazy constraints and user cuts, and using the CPLEX naming convention, appending 'local' or 'Local' where applicable: e.g. '@addLazyConstraintLocal' instead of '@addLazyConstraint', etc (in the CPLEX C Api the variant is 'cutcallbackaddlocal' instead of 'cutcallbackadd').

Do you think this way of proceeding is consistent with the packages design, or would it be preferable to handle the feature by passing a parameter value (as in AIMMS) throughout the 'call chain' instead - e.g. for maintenance purposes ? And displaying an error message when used with solvers not supporting the feature ?

Thanks a lot!,

Kind Regards,

Mehdi


*http://www.ibm.com/support/knowledgecenter/SS9UKU_12.6.0/com.ibm.cplex.zos.help/refcallablelibrary/mipapi/cutcallbackaddlocal.html