### PR TITLE
Revise SDP format

### DIFF
--- a/doc/conic.rst
+++ b/doc/conic.rst
@@ -63,6 +63,10 @@ Not all solvers are expected to support all types of cones. However, when a simp
     by inverting this formula, when :math:`y` elements are specified in
     ``indices``, the corresponding matrix has
     :math:`\left(\sqrt{\frac{1}{4}+2y}-\frac{1}{2}\right) \times \left(\sqrt{\frac{1}{4}+2y}-\frac{1}{2}\right)` elements.
+    The off-diagonal terms of the semidefinite cone are rescaled by
+    :math:`\sqrt{2}` to preserve inner products in the flattened vector
+    space. See page 3 of `Vandenberghe <http://www.seas.ucla.edu/~vandenbe/publications/coneprog.pdf>`_ for more discussion of the vector representation
+    of symmetric matrices.
 
 .. function:: getdual(m::AbstractConicModel)
 

--- a/test/conicinterface.jl
+++ b/test/conicinterface.jl
@@ -602,6 +602,23 @@ function conicSDPtest(s::MathProgBase.AbstractMathProgSolver;duals=false, tol=1e
     pobj = MathProgBase.getobjval(m)
     @test_approx_eq_eps pobj -1.80002643 tol
     
-    # TODO add primal and dual solution tests (after we know what they actually are)
+    x = MathProgBase.getsolution(m)
+    @test all(x[1:6] .> -tol)
+    con = b - A * x 
+    @test eigmin([con[8] con[9] ; con[9] con[10]]) > -tol
+    @test con[1] >= -tol
+    @test all(con[2:7] .<= tol)
+    @test_approx_eq_eps con[11] 0. tol
     
+    if dual
+        y = MathProgBase.getdual(m)
+        @test eigmin([y[8] y[9] ; y[9] y[10]]) > -tol
+        @test y[1] >= -tol
+        @test all(y[2:7] .<= tol)
+        @test_approx_eq_eps y[11] 0. tol
+        var = c + A' * y
+        @test all(var[1:6] .>= -tol)
+        dobj = dot(y,b)
+        @test_approx_eq_eps pobj dobj tol
+    end
 end

--- a/test/conicinterface.jl
+++ b/test/conicinterface.jl
@@ -567,7 +567,7 @@ function conicSDPtest(s::MathProgBase.AbstractMathProgSolver;duals=false, tol=1e
         comp_dobj = dot(-y,[1.0, 0.5])
         @test_approx_eq_eps (comp_pobj/comp_dobj) 1.0 tol
         
-        s = MathProgBase.getreducedcosts(m)
+        s = c + A' * y
         m1 = [ 1 0 0 ; 0 1 0 ; 0 0 1 ]
         m2 = [ 1 1 1 ; 1 1 1 ; 1 1 1 ]
         m3 = [ 2 1 0 ; 1 2 1 ; 0 1 2 ]
@@ -613,12 +613,13 @@ function conicSDPtest(s::MathProgBase.AbstractMathProgSolver;duals=false, tol=1e
     if dual
         y = MathProgBase.getdual(m)
         @test eigmin([y[8] y[9] ; y[9] y[10]]) > -tol
+        y[9] *= sqrt(2) # SVec rescaling per http://docs.mosek.com/slides/ismp2012/sdo.pdf
         @test y[1] >= -tol
         @test all(y[2:7] .<= tol)
         @test_approx_eq_eps y[11] 0. tol
         var = c + A' * y
         @test all(var[1:6] .>= -tol)
-        dobj = dot(y,b)
+        dobj = -dot(y,b)
         @test_approx_eq_eps pobj dobj tol
     end
 end

--- a/test/conicinterface.jl
+++ b/test/conicinterface.jl
@@ -513,68 +513,70 @@ end
 
 
 function conicSDPtest(s::MathProgBase.AbstractMathProgSolver;duals=false, tol=1e-6)
-
-    function is_symmetric(A::Matrix)
-        return all(A - A' .< 1e-4)
-    end
-
-    # Problem 5 - SDP
-    # min y[1, 2]
-    #  st y[2, 1] == 1
-    #     y in SDP cone
-    # If symmetricity constraint is working, y[1, 2] will be 1 else unbounded
-    m = MathProgBase.ConicModel(s)
-    c = [0, 1, 0, 0, 0, 0, 0, 0, 0];
-    A = -eye(9)
-    A = [A; [0, 0, 0, 1, 0, 0, 0, 0, 0]']
-    b = zeros(size(A, 1), 1)
-    b[10] = 1
-    MathProgBase.loadproblem!(m, c, A, b, [(:SDP, 1:9), (:Zero, 10:10)], [(:Free, 1:9)])
+    # Problem 5 - sdo1 from MOSEK docs
+    # From Mosek.jl/test/mathprogtestextra.jl, under license:
+    #   Copyright (c) 2013 Ulf Worsoe, Mosek ApS
+    #   Permission is hereby granted, free of charge, to any person obtaining a copy of this 
+    #   software and associated documentation files (the "Software"), to deal in the Software 
+    #   without restriction, including without limitation the rights to use, copy, modify, merge, 
+    #   publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons 
+    #   to whom the Software is furnished to do so, subject to the following conditions:
+    #   The above copyright notice and this permission notice shall be included in all copies or 
+    #   substantial portions of the Software.
+    #
+    #     | 2 1 0 |
+    # min | 1 2 1 | . X + x1
+    #     | 0 1 2 |
+    #
+    #
+    # s.t. | 1 0 0 |
+    #      | 0 1 0 | . X + x1 = 1
+    #      | 0 0 1 |
+    #
+    #      | 1 1 1 |
+    #      | 1 1 1 | . X + x2 + x3 = 1/2
+    #      | 1 1 1 |
+    #
+    #      (x1,x2,x3) in C^3_q
+    #      X in C_sdp
+    #
+    println("Problem 5")
+    
+    m = MathProgBase.ConicModel(solver)
+    #     x1   x2   x3    X11  X21  X31  X22  X32  X33
+    c = [ 1.0, 0.0, 0.0,  2.0, 2.0, 0.0, 2.0, 2.0, 2.0 ]
+    A = [ 1.0  0.0  0.0   1.0  0.0  0.0  1.0  0.0  1.0 ;  # A1
+          0.0  1.0  1.0   1.0  2.0  2.0  1.0  2.0  1.0 ]  # A2
+    b = [ 1.0, 0.5 ]
+    
+    MathProgBase.loadproblem!(m, c, A, b, [(:Zero,1:2)], [(:SOC,1:3),(:SDP,4:9)] )
     MathProgBase.optimize!(m)
     @test MathProgBase.status(m) == :Optimal
-    @test is_symmetric(reshape(MathProgBase.getsolution(m), 3, 3))
-    @test_approx_eq_eps MathProgBase.getsolution(m)[2] 1.0 tol
-    @test_approx_eq_eps MathProgBase.getsolution(m)[4] 1.0 tol
-    if duals
-        # cvx_begin
-        #  variable y(3,3)
-        #  dual variables a b;
-        #  minimize y(1,2)
-        #  subject to
-        #  a : y(2,1) == 1;
-        #  b : y == semidefinite(3)
-        # cvx_end
-        # gives
-        # a = 1
-        # b = [0 1 0; -1 0 0; 0 0 0]
-        d = MathProgBase.getdual(m)
-        @test_approx_eq_eps d[1] 0 tol
-        @test_approx_eq_eps d[2] -1 tol;
-        @test_approx_eq_eps d[3] 0 tol;
-        @test_approx_eq_eps d[4] 1 tol;
-        @test_approx_eq_eps d[5] 0 tol;
-        @test_approx_eq_eps d[6] 0 tol;
-        @test_approx_eq_eps d[7] 0 tol;
-        @test_approx_eq_eps d[8] 0 tol;
-        @test_approx_eq_eps d[9] 0 tol;
-        @test_approx_eq_eps d[10] 1 tol
-    end
+    pobj = MathProgBase.getobjval(m)
+    @test_approx_eq_eps pobj 7.05710509e-01 tol
+    
+    xx = MathProgBase.getsolution(m)
+    x123 = xx[1:3]
+    X = xx[4:9]
 
-    # Problem 5A - SDP
-    # Same as problem 5, except we enforce :SDP on the var_cone
-    m = MathProgBase.ConicModel(s)
-    c = [0, 1, 0, 0, 0, 0, 0, 0, 0];
-    A = [0, 0, 0, 1, 0, 0, 0, 0, 0]'
-    b = [1]
-    MathProgBase.loadproblem!(m, c, A, b, [(:Zero, 1:1)], [(:SDP, 1:9)])
-    MathProgBase.optimize!(m)
-    @test MathProgBase.status(m) == :Optimal
-    @test is_symmetric(reshape(MathProgBase.getsolution(m), 3, 3))
-    @test_approx_eq_eps MathProgBase.getsolution(m)[2] 1.0 tol
-    @test_approx_eq_eps MathProgBase.getsolution(m)[4] 1.0 tol
     if duals
-        d = MathProgBase.getdual(m)
-        @test_approx_eq_eps d[1] 1 tol
+        y = MathProgBase.getdual(m)
+        # Check primal objective
+        comp_pobj = dot(X,[2.0,2.0,0.0, 2.0,2.0, 2.0]) + x123[1]
+        # Check dual objective
+        comp_dobj = dot(-y,[1.0, 0.5])
+        @test_approx_eq_eps (comp_pobj/comp_dobj) 1.0 tol
+        
+        s = MathProgBase.getreducedcosts(m)
+        m1 = [ 1 0 0 ; 0 1 0 ; 0 0 1 ]
+        m2 = [ 1 1 1 ; 1 1 1 ; 1 1 1 ]
+        m3 = [ 2 1 0 ; 1 2 1 ; 0 1 2 ]
+        M = [s[4] s[5] s[6]
+             s[5] s[7] s[8]
+             s[6] s[8] s[9]]
+        
+        @test (s[2]^2 + s[3]^2 - s[1]^2) < tol # (s[1],s[2],s[3]) in SOC
+        @test_approx_eq_eps sum(abs(m1*y[1]+m2*y[2]+m3 - M)) 0. tol
+        @test eigmin(M) > -tol
     end
-
 end


### PR DESCRIPTION
@chriscoey and I realized that the current SDP lower triangular format (https://github.com/JuliaOpt/MathProgBase.jl/issues/51 https://github.com/JuliaOpt/MathProgBase.jl/pull/55 https://github.com/cvxgrp/scs/issues/31) is a bad idea. Because the lower triangle is not self dual in R^(n*(n+1)/2), it means that our primal-dual pair in the MathProgBase documentation is flat out incorrect and it's painful to handle this discrepancy in a general conic solver like Pajarito because it means rescaling problem data and primal/dual solutions all over the place. Given that we have a generic conic interface, I don't think we have a choice but to present a coherent primal-dual pair. We could revert back to the full matrix SDP form, but that seems like a waste, so I'm proposing to adopt the [svec](http://docs.mosek.com/slides/ismp2012/sdo.pdf) format where off-diagonal terms are rescaled by sqrt(2).

This PR updates the SDP tests for the new format. I have SCS and Mosek passing on local branches and I'll make the rounds of updating Convex.jl and JuMP. We'll need to tag a new 0.x release of MPB once this goes through.

Doc updates are still TODO.

CC @madeleineudell @bodono @ulfworsoe @erling-d-andersen @joehuchette @IainNZ 

Closes #78 
Supersedes #107 