### PR TITLE
single method for all MPB parameters

### DIFF
--- a/doc/solverinterface.rst
+++ b/doc/solverinterface.rst
@@ -117,16 +117,14 @@ All abstract model types inherit from the abstract type ``AbstractMathProgModel`
 
     Returns a vector indicating the types of each variable, with values described above.
 
-It is the philosophy of MathProgBase to not abstract over most solver parameters, because very few are universal, and we do not want to make it difficult for users who already familiar with the parameters of their solver of choice. However, in certain situations an abstraction over parameters is needed, for example, in meta-solvers which must adjust parameters of a subsolver inside a loop. Parameters set using these methods should override any parameters provided in a solver-dependent way. Solvers/models may chose to implement the following methods:
+It is the philosophy of MathProgBase to not abstract over most solver parameters, because very few are universal, and we do not want to make it difficult for users who already familiar with the parameters of their solver of choice. However, in certain situations an abstraction over parameters is needed, for example, in meta-solvers which must adjust parameters of a subsolver inside a loop. Parameters set using these methods should override any parameters provided in a solver-dependent way. Solvers/models may chose to implement the following method:
 
-.. function:: settimelimit!(m::Union{AbstractMathProgSolver,AbstractMathProgModel}, t::Float64)
+.. function:: setparameters!(m::Union{AbstractMathProgSolver,AbstractMathProgModel}; kwargs...)
 
-    If the solve is not completed to optimality tolerances
-    within ``t`` seconds, the solver should return
-    immediately with status ``:UserLimit``.
+    Sets solver-independent parameters via keyword arguments. Curent valid parameters are ``TimeLimit`` and ``Silent``.
+    ``TimeLimit`` (``Float64``): If the solve is not completed to optimality tolerances within the given number of seconds, the solver
+    should return immediately with status ``:UserLimit``.
+    ``Silent`` (``Bool``): If set to true, the solver should disable any output to the console. If set to false, the parameter
+    has no effect.
 
-.. function:: setdisplayoutput!(m::Union{AbstractMathProgSolver,AbstractMathProgModel}, flag::Bool)
-
-    If ``flag=false`` then the solver should be set to the minimum display level. If ``flag=true`` then the default level is retained.
-
-If these parameter-setting methods are called on an ``AbstractMathProgSolver``, then they should apply to all new models created from the solver (but not existing models). If they are called on an ``AbstractMathProgModel``, they should apply to that model only.
+If these parameter-setting methods are called on an ``AbstractMathProgSolver``, then they should apply to all new models created from the solver (but not existing models). If they are called on an ``AbstractMathProgModel``, they should apply to that model only. Unrecognized parameters (those not listed above) should be ignored or trigger a warning message.

--- a/src/SolverInterface/SolverInterface.jl
+++ b/src/SolverInterface/SolverInterface.jl
@@ -74,8 +74,7 @@ end
 
 # solver parameters, may be implemented by AbstractMathProgModel or AbstractMathProgSolver
 @define_interface begin
-    settimelimit!
-    setdisplayoutput!
+    setparameters!
 end
 
 


### PR DESCRIPTION
I sat down to start implementing the parameters and realized that @ccoffrin's idea makes more sense. Here's the use case:
Say you're reusing a JuMP model inside a loop and want to adjust the MPB solver parameters. Setting the parameters directly on JuMP's internal model is not safe because we don't make any guarantees that we will reuse the internal model on the next solve. Creating a new solver and calling ``setsolver`` forces JuMP to throw away the internal model which isn't good. If we move to the single-method model in this PR then you can do something like
```jl
# m is a JuMP model
MathProgBase.setparameters!(m, TimeLimit=100.0, Silent=true)
```
and JuMP could store the list of parameters and guarantee that it will pass them to the solver whether it decides to reuse the current internal model or not. This is much more difficult if we have a separate method for each parameter.

@IainNZ @joehuchette @madeleineudell @JackDunnNZ @yeesian @dpo @ulfworsoe @odow @chriscoey 