### PR TITLE
Separation of `linprog()` into `buildlp()` and `solvelp()`

### DIFF
--- a/doc/linprog.rst
+++ b/doc/linprog.rst
@@ -159,9 +159,3 @@ If ``status`` is ``:Optimal``, the other members have the following values:
 
   - ``redcost`` -- dual multipliers for active variable bounds (zero if inactive)
   - ``lambda`` -- dual multipliers for active linear constraints (equalities are always active)
-
-If ``status`` is ``:Infeasible``, the ``attrs`` member will contain an ``infeasibilityray`` if available; similarly for ``:Unbounded`` problems, ``attrs`` will contain an ``unboundedray`` if available.
-
-..
-  - ``colbasis`` -- optimal simplex basis statuses for the variables (columns) if available. Possible values are ``:NonbasicAtLower``, ``:NonbasicAtUpper``, ``:Basic``, and ``:Superbasic`` (not yet implemented by any solvers)
-  - ``rowbasis`` -- optimal simplex basis statuses for the constraints (rows) if available (not yet implemented by any solvers)

--- a/doc/linprog.rst
+++ b/doc/linprog.rst
@@ -148,14 +148,3 @@ The ``solvelp`` function returns an instance of the type::
         sol
         attrs
     end
-
-where ``status`` is a termination status symbol, one of ``:Optimal``, ``:Infeasible``, ``:Unbounded``, ``:UserLimit`` (iteration limit or timeout), ``:Error`` (and maybe others).
-
-If ``status`` is ``:Optimal``, the other members have the following values:
-
-* ``objval`` -- optimal objective value
-* ``sol`` -- primal solution vector
-* ``attrs`` -- a dictionary that may contain other relevant attributes such as:
-
-  - ``redcost`` -- dual multipliers for active variable bounds (zero if inactive)
-  - ``lambda`` -- dual multipliers for active linear constraints (equalities are always active)

--- a/doc/linprog.rst
+++ b/doc/linprog.rst
@@ -20,18 +20,18 @@ where:
 *    ``l`` is the vector of lower bounds on the variables
 *    ``u`` is the vector of upper bounds on the variables, and
 *    ``solver`` is an *optional* parameter specifying the desired solver, see :ref:`choosing solvers <choosing-solvers>`. If this parameter is not provided, the default solver is used.
- 
+
 A scalar is accepted for the ``b``, ``sense``, ``l``, and ``u`` arguments, in which case its value is replicated. The values ``-Inf`` and ``Inf`` are interpreted to mean that there is no corresponding lower or upper bound.
 
 .. note::
-    Linear programming solvers extensively exploit the sparsity of the constraint matrix ``A``. While both dense and sparse matrices are accepted, for large-scale problems sparse matrices should be provided if permitted by the problem structure.  
+    Linear programming solvers extensively exploit the sparsity of the constraint matrix ``A``. While both dense and sparse matrices are accepted, for large-scale problems sparse matrices should be provided if permitted by the problem structure.
 
 A shortened version is defined as::
 
     linprog(c, A, sense, b, solver) = linprog(c, A, sense, b, 0, Inf, solver)
 
 The ``linprog`` function returns an instance of the type::
-    
+
     type LinprogSolution
         status
         objval
@@ -66,7 +66,7 @@ For example, we can solve the two-dimensional problem (see ``test/linprog.jl``):
 by::
 
     using MathProgBase
-    
+
     sol = linprog([-1,0],[2 1],'<',1.5)
     if sol.status == :Optimal
         println("Optimal objective value is $(sol.objval)")
@@ -94,9 +94,74 @@ where:
 *    ``l`` is the vector of lower bounds on the variables
 *    ``u`` is the vector of upper bounds on the variables, and
 *    ``solver`` is an *optional* parameter specifying the desired solver, see :ref:`choosing solvers <choosing-solvers>`. If this parameter is not provided, the default solver is used.
- 
+
 A scalar is accepted for the ``l``, ``u``, ``lb``, and ``ub`` arguments, in which case its value is replicated. The values ``-Inf`` and ``Inf`` are interpreted to mean that there is no corresponding lower or upper bound. Equality constraints are specified by setting the row lower and upper bounds to the same value.
 
 A shortened version is defined as::
 
     linprog(c, A, lb, ub, solver) = linprog(c, A, lb, ub, 0, Inf, solver)
+
+.. note::
+    The function ``linprog`` calls two independent functions for building and solving the linear programming problem, namely ``buildlp`` and ``solvelp``.
+
+.. function:: buildlp(c, A, sense, b, l, u, solver)
+
+Builds the linear programming problem as defined in ``linprog`` and accepts the following arguments:
+
+*    ``c`` is the objective vector, always in the sense of minimization
+*    ``A`` is the constraint matrix
+*    ``sense`` is a vector of constraint sense characters ``'<'``, ``'='``, and ``'>'``
+*    ``b`` is the right-hand side vector
+*    ``l`` is the vector of lower bounds on the variables
+*    ``u`` is the vector of upper bounds on the variables, and
+*    ``solver`` is an *optional* parameter specifying the desired solver, see :ref:`choosing solvers <choosing-solvers>`. If this parameter is not provided, the default solver is used.
+
+A scalar is accepted for the ``b``, ``sense``, ``l``, and ``u`` arguments, in which case its value is replicated. The values ``-Inf`` and ``Inf`` are interpreted to mean that there is no corresponding lower or upper bound.
+
+.. function:: buildlp(c, A, lb, ub, l, u, solver)
+
+This variant of ``buildlp`` allows to specify two-sided linear constraints (also known as range constraints) similar to ``linprog``, and accepts the following arguments:
+
+*    ``c`` is the objective vector, always in the sense of minimization
+*    ``A`` is the constraint matrix
+*    ``lb`` is the vector of row lower bounds
+*    ``ub`` is the vector of row upper bounds
+*    ``l`` is the vector of lower bounds on the variables
+*    ``u`` is the vector of upper bounds on the variables, and
+*    ``solver`` is an *optional* parameter specifying the desired solver, see :ref:`choosing solvers <choosing-solvers>`. If this parameter is not provided, the default solver is used.
+
+A scalar is accepted for the ``l``, ``u``, ``lb``, and ``ub`` arguments, in which case its value is replicated. The values ``-Inf`` and ``Inf`` are interpreted to mean that there is no corresponding lower or upper bound. Equality constraints are specified by setting the row lower and upper bounds to the same value.
+
+The ``buildlp`` function returns an ``AbstractLinearQuadraticModel`` that can be input to ```solvelp``` in order to obtain a solution.
+
+.. function:: solvelp(m)
+
+Solves the linear programming problem as defined in ``linprog``` and accepts the following argument:
+
+*    ``m`` is an ``AbstractLinearQuadraticModel`` (e.g., as returned by ``buildlp``).
+
+The ``solvelp`` function returns an instance of the type::
+
+    type LinprogSolution
+        status
+        objval
+        sol
+        attrs
+    end
+
+where ``status`` is a termination status symbol, one of ``:Optimal``, ``:Infeasible``, ``:Unbounded``, ``:UserLimit`` (iteration limit or timeout), ``:Error`` (and maybe others).
+
+If ``status`` is ``:Optimal``, the other members have the following values:
+
+* ``objval`` -- optimal objective value
+* ``sol`` -- primal solution vector
+* ``attrs`` -- a dictionary that may contain other relevant attributes such as:
+
+  - ``redcost`` -- dual multipliers for active variable bounds (zero if inactive)
+  - ``lambda`` -- dual multipliers for active linear constraints (equalities are always active)
+
+If ``status`` is ``:Infeasible``, the ``attrs`` member will contain an ``infeasibilityray`` if available; similarly for ``:Unbounded`` problems, ``attrs`` will contain an ``unboundedray`` if available.
+
+..
+  - ``colbasis`` -- optimal simplex basis statuses for the variables (columns) if available. Possible values are ``:NonbasicAtLower``, ``:NonbasicAtUpper``, ``:Basic``, and ``:Superbasic`` (not yet implemented by any solvers)
+  - ``rowbasis`` -- optimal simplex basis statuses for the constraints (rows) if available (not yet implemented by any solvers)

--- a/src/HighLevelInterface/linprog.jl
+++ b/src/HighLevelInterface/linprog.jl
@@ -98,4 +98,6 @@ end
 
 linprog(c,A,rowlb,rowub, solver::AbstractMathProgSolver = MathProgBase.defaultLPsolver) = linprog(c,A,rowlb,rowub,0,Inf, solver)
 
-export linprog
+buildlp(c,A,rowlb,rowub, solver::AbstractMathProgSolver = MathProgBase.defaultLPsolver) = buildlp(c,A,rowlb,rowub,0,Inf, solver)
+
+export linprog, buildlp, solvelp

--- a/src/HighLevelInterface/linprog.jl
+++ b/src/HighLevelInterface/linprog.jl
@@ -19,83 +19,81 @@ function expandvec(x,len::Integer)
 end
 
 function buildlp(c::InputVector, A::AbstractMatrix, rowlb::InputVector, rowub::InputVector, lb::InputVector, ub::InputVector, solver::AbstractMathProgSolver = MathProgBase.defaultLPsolver)
-  m = LinearQuadraticModel(solver)
-  nrow,ncol = size(A)
+    m = LinearQuadraticModel(solver)
+    nrow,ncol = size(A)
 
-  c = expandvec(c, ncol)
-  rowlbtmp = expandvec(rowlb, nrow)
-  rowubtmp = expandvec(rowub, nrow)
-  lb = expandvec(lb, ncol)
-  ub = expandvec(ub, ncol)
+    c = expandvec(c, ncol)
+    rowlbtmp = expandvec(rowlb, nrow)
+    rowubtmp = expandvec(rowub, nrow)
+    lb = expandvec(lb, ncol)
+    ub = expandvec(ub, ncol)
 
-  # rowlb is allowed to be vector of senses
-  if eltype(rowlbtmp) == Char
-      realtype = eltype(rowubtmp)
-      warn_no_inf(realtype)
-      sense = rowlbtmp
-      rhs = rowubtmp
-      @assert realtype <: Real
+    # rowlb is allowed to be vector of senses
+    if eltype(rowlbtmp) == Char
+        realtype = eltype(rowubtmp)
+        warn_no_inf(realtype)
+        sense = rowlbtmp
+        rhs = rowubtmp
+        @assert realtype <: Real
 
-      rowlb = Array(realtype, nrow)
-      rowub = Array(realtype, nrow)
-      for i in 1:nrow
-          if sense[i] == '<'
-              rowlb[i] = typemin(realtype)
-              rowub[i] = rhs[i]
-          elseif sense[i] == '>'
-              rowlb[i] = rhs[i]
-              rowub[i] = typemax(realtype)
-          elseif sense[i] == '='
-              rowlb[i] = rhs[i]
-              rowub[i] = rhs[i]
-          else
-              error("Unrecognized sense '$(sense[i])'")
-          end
-      end
-  else
-      rowlb = rowlbtmp
-      rowub = rowubtmp
-  end
+        rowlb = Array(realtype, nrow)
+        rowub = Array(realtype, nrow)
+        for i in 1:nrow
+            if sense[i] == '<'
+                rowlb[i] = typemin(realtype)
+                rowub[i] = rhs[i]
+            elseif sense[i] == '>'
+                rowlb[i] = rhs[i]
+                rowub[i] = typemax(realtype)
+            elseif sense[i] == '='
+                rowlb[i] = rhs[i]
+                rowub[i] = rhs[i]
+            else
+                error("Unrecognized sense '$(sense[i])'")
+            end
+        end
+    else
+        rowlb = rowlbtmp
+        rowub = rowubtmp
+    end
 
-  loadproblem!(m, A, lb, ub, c, rowlb, rowub, :Min)
+    loadproblem!(m, A, lb, ub, c, rowlb, rowub, :Min)
 
-  return m
+    return m
 end
 
 function solvelp(m)
-  optimize!(m)
-  stat = status(m)
-  if stat == :Optimal
-      attrs = Dict()
-      attrs[:redcost] = getreducedcosts(m)
-      attrs[:lambda] = getconstrduals(m)
-      return LinprogSolution(stat, getobjval(m), getsolution(m), attrs)
-  elseif stat == :Infeasible
-      attrs = Dict()
-      try
-          attrs[:infeasibilityray] = getinfeasibilityray(m)
-      catch
-          warn("Problem is infeasible, but infeasibility ray (\"Farkas proof\") is unavailable; check that the proper solver options are set.")
-      end
-      return LinprogSolution(stat, nothing, [], attrs)
-  elseif stat == :Unbounded
-      attrs = Dict()
-      try
-          attrs[:unboundedray] = getunboundedray(m)
-      catch
-          warn("Problem is unbounded, but unbounded ray is unavailable; check that the proper solver options are set.")
-      end
-      return LinprogSolution(stat, nothing, [], attrs)
-  else
-      return LinprogSolution(stat, nothing, [], Dict())
-  end
+    optimize!(m)
+    stat = status(m)
+    if stat == :Optimal
+        attrs = Dict()
+        attrs[:redcost] = getreducedcosts(m)
+        attrs[:lambda] = getconstrduals(m)
+        return LinprogSolution(stat, getobjval(m), getsolution(m), attrs)
+    elseif stat == :Infeasible
+        attrs = Dict()
+        try
+            attrs[:infeasibilityray] = getinfeasibilityray(m)
+        catch
+            warn("Problem is infeasible, but infeasibility ray (\"Farkas proof\") is unavailable; check that the proper solver options are set.")
+        end
+        return LinprogSolution(stat, nothing, [], attrs)
+    elseif stat == :Unbounded
+        attrs = Dict()
+        try
+            attrs[:unboundedray] = getunboundedray(m)
+        catch
+            warn("Problem is unbounded, but unbounded ray is unavailable; check that the proper solver options are set.")
+        end
+        return LinprogSolution(stat, nothing, [], attrs)
+    else
+        return LinprogSolution(stat, nothing, [], Dict())
+    end
 end
 
 function linprog(c::InputVector, A::AbstractMatrix, rowlb::InputVector, rowub::InputVector, lb::InputVector, ub::InputVector, solver::AbstractMathProgSolver = MathProgBase.defaultLPsolver)
-
-  m = buildlp(c, A, rowlb, rowub, lb, ub, solver)
-  return solvelp(m)
-
+    m = buildlp(c, A, rowlb, rowub, lb, ub, solver)
+    return solvelp(m)
 end
 
 linprog(c,A,rowlb,rowub, solver::AbstractMathProgSolver = MathProgBase.defaultLPsolver) = linprog(c,A,rowlb,rowub,0,Inf, solver)

--- a/src/HighLevelInterface/linprog.jl
+++ b/src/HighLevelInterface/linprog.jl
@@ -18,78 +18,86 @@ function expandvec(x,len::Integer)
     end
 end
 
+function buildlp(c::InputVector, A::AbstractMatrix, rowlb::InputVector, rowub::InputVector, lb::InputVector, ub::InputVector, solver::AbstractMathProgSolver = MathProgBase.defaultLPsolver)
+  m = LinearQuadraticModel(solver)
+  nrow,ncol = size(A)
 
+  c = expandvec(c, ncol)
+  rowlbtmp = expandvec(rowlb, nrow)
+  rowubtmp = expandvec(rowub, nrow)
+  lb = expandvec(lb, ncol)
+  ub = expandvec(ub, ncol)
+
+  # rowlb is allowed to be vector of senses
+  if eltype(rowlbtmp) == Char
+      realtype = eltype(rowubtmp)
+      warn_no_inf(realtype)
+      sense = rowlbtmp
+      rhs = rowubtmp
+      @assert realtype <: Real
+
+      rowlb = Array(realtype, nrow)
+      rowub = Array(realtype, nrow)
+      for i in 1:nrow
+          if sense[i] == '<'
+              rowlb[i] = typemin(realtype)
+              rowub[i] = rhs[i]
+          elseif sense[i] == '>'
+              rowlb[i] = rhs[i]
+              rowub[i] = typemax(realtype)
+          elseif sense[i] == '='
+              rowlb[i] = rhs[i]
+              rowub[i] = rhs[i]
+          else
+              error("Unrecognized sense '$(sense[i])'")
+          end
+      end
+  else
+      rowlb = rowlbtmp
+      rowub = rowubtmp
+  end
+
+  loadproblem!(m, A, lb, ub, c, rowlb, rowub, :Min)
+
+  return m
+end
+
+function solvelp(m)
+  optimize!(m)
+  stat = status(m)
+  if stat == :Optimal
+      attrs = Dict()
+      attrs[:redcost] = getreducedcosts(m)
+      attrs[:lambda] = getconstrduals(m)
+      return LinprogSolution(stat, getobjval(m), getsolution(m), attrs)
+  elseif stat == :Infeasible
+      attrs = Dict()
+      try
+          attrs[:infeasibilityray] = getinfeasibilityray(m)
+      catch
+          warn("Problem is infeasible, but infeasibility ray (\"Farkas proof\") is unavailable; check that the proper solver options are set.")
+      end
+      return LinprogSolution(stat, nothing, [], attrs)
+  elseif stat == :Unbounded
+      attrs = Dict()
+      try
+          attrs[:unboundedray] = getunboundedray(m)
+      catch
+          warn("Problem is unbounded, but unbounded ray is unavailable; check that the proper solver options are set.")
+      end
+      return LinprogSolution(stat, nothing, [], attrs)
+  else
+      return LinprogSolution(stat, nothing, [], Dict())
+  end
+end
 
 function linprog(c::InputVector, A::AbstractMatrix, rowlb::InputVector, rowub::InputVector, lb::InputVector, ub::InputVector, solver::AbstractMathProgSolver = MathProgBase.defaultLPsolver)
-    m = LinearQuadraticModel(solver)
-    nrow,ncol = size(A)
 
-    c = expandvec(c, ncol)
-    rowlbtmp = expandvec(rowlb, nrow)
-    rowubtmp = expandvec(rowub, nrow)
-    lb = expandvec(lb, ncol)
-    ub = expandvec(ub, ncol)
-    
-    # rowlb is allowed to be vector of senses
-    if eltype(rowlbtmp) == Char
-        realtype = eltype(rowubtmp)
-        warn_no_inf(realtype)
-        sense = rowlbtmp
-        rhs = rowubtmp
-        @assert realtype <: Real
+  m = buildlp(c, A, rowlb, rowub, lb, ub, solver)
+  return solvelp(m)
 
-        rowlb = Array(realtype, nrow)
-        rowub = Array(realtype, nrow)
-        for i in 1:nrow
-            if sense[i] == '<'
-                rowlb[i] = typemin(realtype)
-                rowub[i] = rhs[i]
-            elseif sense[i] == '>'
-                rowlb[i] = rhs[i]
-                rowub[i] = typemax(realtype)
-            elseif sense[i] == '='
-                rowlb[i] = rhs[i]
-                rowub[i] = rhs[i]
-            else
-                error("Unrecognized sense '$(sense[i])'")
-            end
-        end
-    else
-        rowlb = rowlbtmp
-        rowub = rowubtmp
-    end
-    
-    loadproblem!(m, A, lb, ub, c, rowlb, rowub, :Min)
-    optimize!(m)
-    stat = status(m)
-    if stat == :Optimal
-        attrs = Dict()
-        attrs[:redcost] = getreducedcosts(m)
-        attrs[:lambda] = getconstrduals(m)
-        return LinprogSolution(stat, getobjval(m), getsolution(m), attrs)
-    elseif stat == :Infeasible
-        attrs = Dict()
-        try
-            attrs[:infeasibilityray] = getinfeasibilityray(m)
-        catch
-            warn("Problem is infeasible, but infeasibility ray (\"Farkas proof\") is unavailable; check that the proper solver options are set.")
-        end
-        return LinprogSolution(stat, nothing, [], attrs)
-    elseif stat == :Unbounded
-        attrs = Dict()
-        try
-            attrs[:unboundedray] = getunboundedray(m)
-        catch
-            warn("Problem is unbounded, but unbounded ray is unavailable; check that the proper solver options are set.")
-        end
-        return LinprogSolution(stat, nothing, [], attrs)
-    else
-        return LinprogSolution(stat, nothing, [], Dict())
-    end
 end
 
 linprog(c,A,rowlb,rowub, solver::AbstractMathProgSolver = MathProgBase.defaultLPsolver) = linprog(c,A,rowlb,rowub,0,Inf, solver)
 
 export linprog
-
-

--- a/src/MathProgBase.jl
+++ b/src/MathProgBase.jl
@@ -17,6 +17,6 @@ include("defaultsolvers.jl")
 
 include(joinpath(dirname(@__FILE__),"HighLevelInterface","HighLevelInterface.jl"))
 using .HighLevelInterface
-export linprog, mixintprog, quadprog
+export linprog, mixintprog, quadprog, buildlp, solvelp
 
 end

--- a/test/linprog.jl
+++ b/test/linprog.jl
@@ -2,17 +2,33 @@ using Base.Test
 using MathProgBase
 
 function linprogtest(solver=MathProgBase.defaultLPsolver; objtol = 1e-7, primaltol = 1e-6)
-    println("Testing linprog with solver ", string(typeof(solver)))
+    println("Testing linprog and subfunctions with solver ", string(typeof(solver)))
     # min -x
     # s.t. 2x + y <= 1.5
     # x,y >= 0
     # solution is (0.75,0) with objval -0.75
 
+    # test buildlp and solvelp
+    m = buildlp([-1,0],[2 1],'<',1.5,solver)
+    sol = solvelp(m)
+    @test sol.status == :Optimal
+    @test_approx_eq_eps sol.objval -0.75 objtol
+    @test_approx_eq_eps norm(sol.sol - [0.75,0.0]) 0 primaltol
+
+    # test linprog
     sol = linprog([-1,0],[2 1],'<',1.5,solver)
     @test sol.status == :Optimal
     @test_approx_eq_eps sol.objval -0.75 objtol
     @test_approx_eq_eps norm(sol.sol - [0.75,0.0]) 0 primaltol
 
+    # test buildlp and solvelp
+    m = buildlp([-1,0],[2 1],'<',1.5,solver)
+    sol = solvelp(m)
+    @test sol.status == :Optimal
+    @test_approx_eq_eps sol.objval -0.75 objtol
+    @test_approx_eq_eps norm(sol.sol - [0.75,0.0]) 0 primaltol
+
+    # test linprog
     sol = linprog([-1,0],sparse([2 1]),'<',1.5,solver)
     @test sol.status == :Optimal
     @test_approx_eq_eps sol.objval -0.75 objtol
@@ -22,16 +38,33 @@ function linprogtest(solver=MathProgBase.defaultLPsolver; objtol = 1e-7, primalt
     # min x
     # s.t. 2x+y <= -1
     # x,y >= 0
+
+    # test buildlp and solvelp
+    m = buildlp([1,0],[2 1],'<',-1,solver)
+    sol = solvelp(m)
+    @test sol.status == :Infeasible
+
+    r = sol.attrs[:infeasibilityray][1]
+    @test_approx_eq r/abs(r) -1.0
+
+    # test linprog
     sol = linprog([1,0],[2 1],'<',-1,solver)
     @test sol.status == :Infeasible
 
-    r = sol.attrs[:infeasibilityray][1] 
+    r = sol.attrs[:infeasibilityray][1]
     @test_approx_eq r/abs(r) -1.0
 
     # test unbounded problem:
     # min -x-y
     # s.t. -x+2y <= 0
     # x,y >= 0
+
+    # test buildlp and solvelp
+    m = buildlp([-1,-1],[-1 2],'<',[0],solver)
+    sol = solvelp(m)
+    @test sol.status == :Unbounded
+
+    # test linprog
     sol = linprog([-1,-1],[-1 2],'<',[0],solver)
     @test sol.status == :Unbounded
 
@@ -39,6 +72,15 @@ function linprogtest(solver=MathProgBase.defaultLPsolver; objtol = 1e-7, primalt
     # min -x-y
     # s.t. x-y == 0
     # x,y >= 0
+
+    # test buildlp and solvelp
+    m = buildlp([-1,-1],[1 -1],'=',0,solver)
+    sol = solvelp(m)
+    @test sol.status == :Unbounded
+    @test sol.attrs[:unboundedray][1] > 1e-7
+    @test_approx_eq sol.attrs[:unboundedray][1] sol.attrs[:unboundedray][2]
+
+    # test linprog
     sol = linprog([-1,-1],[1 -1],'=',0,solver)
     @test sol.status == :Unbounded
     @test sol.attrs[:unboundedray][1] > 1e-7
@@ -47,6 +89,3 @@ function linprogtest(solver=MathProgBase.defaultLPsolver; objtol = 1e-7, primalt
 
     println("Passed")
 end
-
-
-


### PR DESCRIPTION
In order to be able to use the high-level interface of `MathProgBase.jl` more efficiently and with a higher flexibility, I suggest to split `linprog()` into 2 separate functions:

- `buildlp()` with the same arguments as `linprog()`
- `solvelp()` with the output of `buildlp()`

This then allows to call `buildlp()` and `solvelp()` directly using `m = MathProgBase.HighLevelInterface.buildlp(...)` or `MathProgBase.HighLevelInterface.solvelp(m)`. This is particularly useful when the same model is solved in a loop and with a changing objective.

All tests passed on Linux x86_64 using Julia 0.5.0 by running
```Julia
julia> Pkg.test("MathProgBase")
```