### PR TITLE
Add Xpress to defaultsolvers.jl

### DIFF
--- a/src/defaultsolvers.jl
+++ b/src/defaultsolvers.jl
@@ -5,18 +5,21 @@ const LPsolvers = [(:Clp,:ClpSolver),
                    (:GLPKMathProgInterface,:GLPKSolverLP),
                    (:Gurobi,:GurobiSolver),
                    (:CPLEX,:CplexSolver),
-                   (:Mosek,:MosekSolver)]
+                   (:Mosek,:MosekSolver),
+                   (:Xpress,:XpressSolver)]
 
 const MIPsolvers = [(:Cbc,:CbcSolver),
                     (:GLPKMathProgInterface,:GLPKSolverMIP),
                     (:Gurobi,:GurobiSolver),
                     (:CPLEX,:CplexSolver),
-                    (:Mosek,:MosekSolver)]
+                    (:Mosek,:MosekSolver),
+                    (:Xpress,:XpressSolver)]
 
 const QPsolvers = [(:Gurobi,:GurobiSolver),
                    (:CPLEX,:CplexSolver),
                    (:Mosek,:MosekSolver),
-                   (:Ipopt,:IpoptSolver)]
+                   (:Ipopt,:IpoptSolver),
+                   (:Xpress,:XpressSolver)]
 
 const SDPsolvers = [(:Mosek,:MosekSolver),
                     (:SCS,:SCSSolver)]


### PR DESCRIPTION
I tagged Xpress 0.1.0 today, its more robust and was more tested, now it passes all JuMP and MathProgBase tests.