### PR TITLE
fix documentation for setwarmstart!

### DIFF
--- a/doc/lpqcqp.rst
+++ b/doc/lpqcqp.rst
@@ -156,13 +156,6 @@ to indicate equality constraints.
 
     Returns the cumulative number of barrier iterations during the optimization process.
 
-.. function:: setwarmstart!(m::AbstractLinearQuadraticModel, v)
-
-    Provide an initial solution ``v`` to the solver, as supported. To leave values undefined, set them
-    to ``NaN``. MIP solvers should ignore provided solutions that are infeasible or
-    cannot be completed to a feasible solution. Nonlinear solvers may use provided
-    solutions as starting points even if infeasible.
-
 Integer Programming
 ^^^^^^^^^^^^^^^^^^^
 

--- a/doc/solverinterface.rst
+++ b/doc/solverinterface.rst
@@ -128,3 +128,11 @@ It is the philosophy of MathProgBase to not abstract over most solver parameters
     has no effect.
 
 If these parameter-setting methods are called on an ``AbstractMathProgSolver``, then they should apply to all new models created from the solver (but not existing models). If they are called on an ``AbstractMathProgModel``, they should apply to that model only. Unrecognized parameters (those not listed above) should be ignored or trigger a warning message.
+
+.. function:: setwarmstart!(m::AbstractMathProgModel, v)
+
+    Provide an initial solution ``v`` to the solver, as supported. To leave values undefined, set them
+    to ``NaN``. MIP solvers should ignore provided solutions that are infeasible or
+    cannot be completed to a feasible solution. Nonlinear solvers may use provided
+    solutions as starting points even if infeasible.
+

--- a/src/SolverInterface/LinearQuadratic.jl
+++ b/src/SolverInterface/LinearQuadratic.jl
@@ -16,7 +16,6 @@ export AbstractLinearQuadraticModel
     setobj!
     addvar!
     addconstr!
-    setwarmstart!
     addsos1!
     addsos2!
     writeproblem

--- a/src/SolverInterface/SolverInterface.jl
+++ b/src/SolverInterface/SolverInterface.jl
@@ -70,6 +70,7 @@ export AbstractMathProgSolver
     setvartype!
     getvartype
     loadproblem!
+    setwarmstart!
 end
 
 # solver parameters, may be implemented by AbstractMathProgModel or AbstractMathProgSolver


### PR DESCRIPTION
Is documented as a function of `AbstractLinearQuadraticModel`, but is already used for `AbstractNonlinearModel` in MPB and JuMP. Now moved to the common functions for `AbstractMathProgModel`.

Discussed in [SCIP.jl/#26](https://github.com/SCIP-Interfaces/SCIP.jl/issues/26).