### PR TITLE
Use Int eltype for constridx in addvar! fallback

### DIFF
--- a/src/SolverInterface/LinearQuadratic.jl
+++ b/src/SolverInterface/LinearQuadratic.jl
@@ -38,7 +38,7 @@ export AbstractLinearQuadraticModel
 end
 
 # default addvar!, not adding to any existing constraints
-addvar!(m::AbstractMathProgModel, collb, colub, objcoef) = addvar!(m, [], [], collb, colub, objcoef)
+addvar!(m::AbstractMathProgModel, collb, colub, objcoef) = addvar!(m, Int[], [], collb, colub, objcoef)
 
 # Quadratic methods
 


### PR DESCRIPTION
Since the first argument of `sparsevec` is of type `AbstractVector{Ti<:Integer}`, it might be reasonable for a solver to require that the second argument of `addvar!` (i.e. `constridx`) also has this type.