### PR TITLE
RFC: new default solver mechanism compatible with Julia 0.6

### DIFF
--- a/src/HighLevelInterface/linprog.jl
+++ b/src/HighLevelInterface/linprog.jl
@@ -18,7 +18,7 @@ function expandvec(x,len::Integer)
     end
 end
 
-function buildlp(c::InputVector, A::AbstractMatrix, rowlb::InputVector, rowub::InputVector, lb::InputVector, ub::InputVector, solver::AbstractMathProgSolver = MathProgBase.defaultLPsolver)
+function buildlp(c::InputVector, A::AbstractMatrix, rowlb::InputVector, rowub::InputVector, lb::InputVector, ub::InputVector, solver::AbstractMathProgSolver = MathProgBase.defaultLPsolver())
     m = LinearQuadraticModel(solver)
     nrow,ncol = size(A)
 
@@ -91,13 +91,13 @@ function solvelp(m)
     end
 end
 
-function linprog(c::InputVector, A::AbstractMatrix, rowlb::InputVector, rowub::InputVector, lb::InputVector, ub::InputVector, solver::AbstractMathProgSolver = MathProgBase.defaultLPsolver)
+function linprog(c::InputVector, A::AbstractMatrix, rowlb::InputVector, rowub::InputVector, lb::InputVector, ub::InputVector, solver::AbstractMathProgSolver = MathProgBase.defaultLPsolver())
     m = buildlp(c, A, rowlb, rowub, lb, ub, solver)
     return solvelp(m)
 end
 
-linprog(c,A,rowlb,rowub, solver::AbstractMathProgSolver = MathProgBase.defaultLPsolver) = linprog(c,A,rowlb,rowub,0,Inf, solver)
+linprog(c,A,rowlb,rowub, solver::AbstractMathProgSolver = MathProgBase.defaultLPsolver()) = linprog(c,A,rowlb,rowub,0,Inf, solver)
 
-buildlp(c,A,rowlb,rowub, solver::AbstractMathProgSolver = MathProgBase.defaultLPsolver) = buildlp(c,A,rowlb,rowub,0,Inf, solver)
+buildlp(c,A,rowlb,rowub, solver::AbstractMathProgSolver = MathProgBase.defaultLPsolver()) = buildlp(c,A,rowlb,rowub,0,Inf, solver)
 
 export linprog, buildlp, solvelp

--- a/src/HighLevelInterface/mixintprog.jl
+++ b/src/HighLevelInterface/mixintprog.jl
@@ -8,7 +8,7 @@ end
 
 typealias SymbolInputVector Union{Vector{Symbol},Symbol}
 
-function mixintprog(c::InputVector, A::AbstractMatrix, rowlb::InputVector, rowub::InputVector, vartypes::SymbolInputVector, lb::InputVector, ub::InputVector, solver::AbstractMathProgSolver = MathProgBase.defaultMIPsolver)
+function mixintprog(c::InputVector, A::AbstractMatrix, rowlb::InputVector, rowub::InputVector, vartypes::SymbolInputVector, lb::InputVector, ub::InputVector, solver::AbstractMathProgSolver = MathProgBase.defaultMIPsolver())
     m = LinearQuadraticModel(solver)
     nrow,ncol = size(A)
 
@@ -59,7 +59,7 @@ function mixintprog(c::InputVector, A::AbstractMatrix, rowlb::InputVector, rowub
     end
 end
 
-mixintprog(c,A,rowlb,rowub,vartypes,solver::AbstractMathProgSolver=defaultMIPsolver) = mixintprog(c,A,rowlb,rowub,vartypes,0,Inf,solver)
+mixintprog(c,A,rowlb,rowub,vartypes,solver::AbstractMathProgSolver=defaultMIPsolver()) = mixintprog(c,A,rowlb,rowub,vartypes,0,Inf,solver)
 
 export mixintprog
 

--- a/src/HighLevelInterface/quadprog.jl
+++ b/src/HighLevelInterface/quadprog.jl
@@ -6,7 +6,7 @@ type QuadprogSolution
     attrs
 end
 
-function quadprog(c::InputVector, Q::AbstractMatrix, A::AbstractMatrix, rowlb::InputVector, rowub::InputVector, lb::InputVector, ub::InputVector, solver::AbstractMathProgSolver = MathProgBase.defaultQPsolver)
+function quadprog(c::InputVector, Q::AbstractMatrix, A::AbstractMatrix, rowlb::InputVector, rowub::InputVector, lb::InputVector, ub::InputVector, solver::AbstractMathProgSolver = MathProgBase.defaultQPsolver())
     m = LinearQuadraticModel(solver)
     nrow,ncol = size(A)
 
@@ -56,6 +56,6 @@ function quadprog(c::InputVector, Q::AbstractMatrix, A::AbstractMatrix, rowlb::I
     end
 end
 
-quadprog(c,Q,A,rowlb,rowub,solver::AbstractMathProgSolver=defaultQPsolver) = quadprog(c,Q,A,rowlb,rowub,0,Inf,solver)
+quadprog(c,Q,A,rowlb,rowub,solver::AbstractMathProgSolver=defaultQPsolver()) = quadprog(c,Q,A,rowlb,rowub,0,Inf,solver)
 
 export quadprog

--- a/src/defaultsolvers.jl
+++ b/src/defaultsolvers.jl
@@ -32,43 +32,51 @@ const Conicsolvers = [(:ECOS,:ECOSSolver),
                       (:SCS,:SCSSolver),
                       (:Mosek,:MosekSolver)]
 
-using Base.Meta
-
-# Don't load packages for default solvers until needed.
-# This reduces the startup time for MathProgBase.
-for solvertype in ["LP", "MIP", "QP", "SDP", "NLP", "Conic"]
-    typename = Symbol("Default"*solvertype*"Solver")
-    @eval begin
-        type $typename <: SolverInterface.AbstractMathProgSolver
+function loaddefaultsolvers()
+    for solverlist in [LPsolvers,MIPsolvers,QPsolvers,SDPsolvers,NLPsolvers,Conicsolvers]
+        for (pkgname,solvername) in solverlist
+            try
+                eval(Expr(:import,pkgname))
+                # stop when we've found a working solver in this category
+                continue
+            end
         end
     end
-    defaultname = Symbol("default"*solvertype*"solver")
-    @eval $defaultname = ($typename)()
+end
 
+using Base.Meta
+
+for solvertype in ["LP", "MIP", "QP", "SDP", "NLP", "Conic"]
     solvers = Symbol(solvertype*"solvers")
-
-
-    for t in (:LinearQuadraticModel,:ConicModel,:NonlinearModel)
-        @eval function SolverInterface.$t(s::$typename)
-            for (pkgname, solvername) in $solvers
+    functionname = Symbol("default"*solvertype*"solver")
+    if VERSION > v"0.6.0-"
+    @eval function ($functionname)()
+        for (pkgname,solvername) in $solvers
+            if isdefined(Main,pkgname)
+                return getfield(getfield(Main,pkgname),solvername)()
+            end
+        end
+        solvers = [String(p) for (p,s) in $solvers]
+        error("No ", $solvertype, " solver detected. The recognized solver packages are: ", solvers,". One of these solvers must be installed and explicitly loaded with a \"using\" statement.")
+    end
+    else
+    @eval function ($functionname)()
+        for (pkgname,solvername) in $solvers
+            alreadydefined = isdefined(Main,pkgname)
+            if !alreadydefined
                 try
                     eval(Expr(:import,pkgname))
+                    # if we got here, package works but wasn't loaded,
+                    # print warning.
+                    Base.warn_once(string("The default ", $solvertype, " package is installed but not loaded. In Julia 0.6 and later, an explicit \"using ", pkgname, "\" statement will be required in order for the solver to be detected and used as a default."))
                 catch
-                    if isdir(Pkg.dir((string(pkgname))))
-                        warn("Package ",string(pkgname),
-                             " is installed but couldn't be loaded. ",
-                             "You may need to run `Pkg.build(\"$pkgname\")`")
-                    end
                     continue
                 end
-                ex = Expr(:(=), $(quot(defaultname)),
-                          Expr(:call, Expr(:., pkgname, quot(solvername))))
-                eval(ex)
-                ex = Expr(:call, $(quot(t)), $(quot(defaultname)))
-                return eval(ex)
             end
-            suggestions = join(["\"$(pkgname)\", " for (pkgname,solvername) in $solvers], ' ')
-            error("No ",$solvertype, " solver detected. Try installing one of the following packages: ", suggestions, " and restarting Julia")
+            return getfield(getfield(Main,pkgname),solvername)()
         end
+        suggestions = join(["\"$(pkgname)\", " for (pkgname,solvername) in $solvers], ' ')
+        error("No ",$solvertype, " solver detected. Try installing one of the following packages: ", suggestions, " and restarting Julia")
+    end
     end
 end

--- a/test/linprog.jl
+++ b/test/linprog.jl
@@ -1,7 +1,7 @@
 using Base.Test
 using MathProgBase
 
-function linprogtest(solver=MathProgBase.defaultLPsolver; objtol = 1e-7, primaltol = 1e-6)
+function linprogtest(solver=MathProgBase.defaultLPsolver(); objtol = 1e-7, primaltol = 1e-6)
     println("Testing linprog and subfunctions with solver ", string(typeof(solver)))
     # min -x
     # s.t. 2x + y <= 1.5

--- a/test/mixintprog.jl
+++ b/test/mixintprog.jl
@@ -1,7 +1,7 @@
 using Base.Test
 using MathProgBase
 
-function mixintprogtest(solver=MathProgBase.defaultMIPsolver)
+function mixintprogtest(solver=MathProgBase.defaultMIPsolver())
     println("Testing mixintprog with solver ", string(typeof(solver)))
 
     # integer knapsack problem

--- a/test/quadprog.jl
+++ b/test/quadprog.jl
@@ -2,7 +2,7 @@ using Base.Test
 using MathProgBase
 using MathProgBase.SolverInterface
 
-function quadprogtest(solver=MathProgBase.defaultQPsolver)
+function quadprogtest(solver=MathProgBase.defaultQPsolver())
     println("Testing quadprog with solver ", string(typeof(solver)))
 
     sol = quadprog([0., 0., 0.],[2. 1. 0.; 1. 2. 1.; 0. 1. 2.],[1. 2. 3.; 1. 1. 0.],'>',[4., 1.],-Inf,Inf,solver)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 # test default solvers
 
 include("linprog.jl")
+MathProgBase.loaddefaultsolvers()
 linprogtest()
 
 include("mixintprog.jl")
@@ -11,8 +12,8 @@ quadprogtest()
 
 # Test conic fallback for LPs
 include("conicinterface.jl")
-coniclineartest(MathProgBase.defaultLPsolver, duals=true)
+coniclineartest(MathProgBase.defaultLPsolver(), duals=true)
 
 # Test LP fallback for conics
 include("linproginterface.jl")
-linprogsolvertest(MathProgBase.defaultConicsolver)
+linprogsolvertest(MathProgBase.defaultConicsolver())


### PR DESCRIPTION
In 0.6, we can essentially no longer run ``eval`` to load solver packages at runtime when we feel like it. Here's a new design for the default solver mechanism that works.

Module-level constants like ``MathProgBase.defaultLPsolver`` become methods ``MathProgBase.defaultLPsolver()`` which return solver objects. On 0.6 and later, the methods can only look at loaded packages. It's now the user's responsibility to load a capable solver package before solving a model. As a convenience, we provide ``MathProgBase.loaddefaultsolvers()`` which can be put at the top of a script to make everything magically work. On 0.5, I've implemented it to print a helpful warning in the use case that will become an error on 0.6.

This will become MathProgBase 0.6 since it's a breaking change.

CC @blegat @joehuchette @tkelman @jrevels @odow @joaquimg 

Closes https://github.com/JuliaOpt/MathProgBase.jl/issues/148