### PR TITLE
added addindconstr! interface for indicator constraints

### DIFF
--- a/doc/lpqcqp.rst
+++ b/doc/lpqcqp.rst
@@ -108,6 +108,16 @@ to indicate equality constraints.
     are specified in a sparse format: the ``coef`` vector contains the nonzero
     coefficients, and the ``varidx`` vector contains the indices of the corresponding
     variables.
+    
+.. function:: addindconstr!(m::AbstractLinearQuadraticModel, ind, comp, varidx, coef, lb, ub)
+
+    Adds a new indicator constraint to the model, of the form
+.. math::
+    y = 1 \Rightarrow ax \leq b
+    
+    ``ind`` is the indicator variable (binary), and ``comp`` is the complement relationship. If bin = 1, comp = true = 0. 
+    The rest of the arguments are the same as addconstr!
+
 
 .. function:: delconstrs!(m::AbstractLinearQuadraticModel, idxs)
 

--- a/doc/lpqcqp.rst
+++ b/doc/lpqcqp.rst
@@ -109,14 +109,13 @@ to indicate equality constraints.
     coefficients, and the ``varidx`` vector contains the indices of the corresponding
     variables.
     
-.. function:: addindconstr!(m::AbstractLinearQuadraticModel, binvar, binval, varidx, coef, lb, ub)
+.. function:: addindconstr!(m::AbstractLinearQuadraticModel, binvar, binval, varidx, coef, sense, rhs)
 
     Adds a new indicator constraint to the model, of the form
 .. math::
     y = 1 \Rightarrow ax \leq b
     
-    ``binvar`` is the indicator variable (binary), and ``binval`` is the value of the binary variable. 
-    The rest of the arguments are the same as addconstr!
+    ``binvar`` is the indicator variable (binary), and ``binval`` is the value of the binary variable. Coefficients for the linear constraint are specified in a sparse format: the ``coef`` vector contains the nonzero coefficients, and the ``varidx`` vector contains the indices of the corresponding variables. ``sense`` is the sense of the linear constraint ``('<','=','>')``, and ``rhs`` is the right hand side.
 
 
 .. function:: delconstrs!(m::AbstractLinearQuadraticModel, idxs)

--- a/doc/lpqcqp.rst
+++ b/doc/lpqcqp.rst
@@ -115,7 +115,9 @@ to indicate equality constraints.
 .. math::
     y = 1 \Rightarrow ax \leq b
     
-    ``binvar`` is the indicator variable (binary), and ``binval`` is the value of the binary variable. Coefficients for the linear constraint are specified in a sparse format: the ``coef`` vector contains the nonzero coefficients, and the ``varidx`` vector contains the indices of the corresponding variables. ``sense`` is the sense of the linear constraint ``('<','=','>')``, and ``rhs`` is the right hand side.
+    ``binvar`` is the index of the indicator variable (binary), and ``binval`` is the value of the binary variable, either ``0`` or ``1``.  Coefficients for the linear constraint are specified in a sparse format: the ``coef`` vector contains the nonzero coefficients, and the ``varidx`` vector contains the indices of the corresponding variables. ``sense`` is the sense of the linear constraint ``('<','=','>')``, and ``rhs`` is the right hand side.
+    
+    This builds the constraint ``binvar = binval => ax <= b``, where ``ax <= b`` is specified with ``(varidx,coef,sense,rhs``)
 
 
 .. function:: delconstrs!(m::AbstractLinearQuadraticModel, idxs)

--- a/doc/lpqcqp.rst
+++ b/doc/lpqcqp.rst
@@ -109,13 +109,13 @@ to indicate equality constraints.
     coefficients, and the ``varidx`` vector contains the indices of the corresponding
     variables.
     
-.. function:: addindconstr!(m::AbstractLinearQuadraticModel, ind, comp, varidx, coef, lb, ub)
+.. function:: addindconstr!(m::AbstractLinearQuadraticModel, binvar, binval, varidx, coef, lb, ub)
 
     Adds a new indicator constraint to the model, of the form
 .. math::
     y = 1 \Rightarrow ax \leq b
     
-    ``ind`` is the indicator variable (binary), and ``comp`` is the complement relationship. If bin = 1, comp = true = 0. 
+    ``binvar`` is the indicator variable (binary), and ``binval`` is the value of the binary variable. 
     The rest of the arguments are the same as addconstr!
 
 

--- a/src/SolverInterface/LinearQuadratic.jl
+++ b/src/SolverInterface/LinearQuadratic.jl
@@ -21,6 +21,7 @@ export AbstractLinearQuadraticModel
     delconstrs!
     addsos1!
     addsos2!
+    addindconstr!
     writeproblem
     getvarLB
     getvarUB


### PR DESCRIPTION
Gurobi (since version 7), CPLEX and SCIP support indicator constraints. Which are something like
```
y = 1  ->   ax <= b
```
added addindconstr! interface to allow the implementation by CPLEX.jl, Gurobi.jl, SCIP.jl and also the implementation in JuMP. An example of usage with CPLEX would be
```
function addindconstr!(m::CplexMathProgModel, ind, comp, varidx, coef, lb, ub)
```
Ref.
http://www.ibm.com/support/knowledgecenter/SSSA5P_12.5.1/ilog.odms.cplex.help/refcallablelibrary/html/functions/CPXaddindconstr.html