### PR TITLE
type -> struct

### DIFF
--- a/src/HighLevelInterface/linprog.jl
+++ b/src/HighLevelInterface/linprog.jl
@@ -1,4 +1,4 @@
-type LinprogSolution
+struct LinprogSolution
     status
     objval
     sol

--- a/src/HighLevelInterface/linprog.jl
+++ b/src/HighLevelInterface/linprog.jl
@@ -1,4 +1,4 @@
-struct LinprogSolution
+type LinprogSolution
     status
     objval
     sol

--- a/src/HighLevelInterface/mixintprog.jl
+++ b/src/HighLevelInterface/mixintprog.jl
@@ -1,4 +1,4 @@
-struct MixintprogSolution
+type MixintprogSolution
     status
     objval
     sol

--- a/src/HighLevelInterface/mixintprog.jl
+++ b/src/HighLevelInterface/mixintprog.jl
@@ -1,5 +1,4 @@
-
-type MixintprogSolution
+struct MixintprogSolution
     status
     objval
     sol
@@ -77,5 +76,3 @@ mixintprog(c,A,rowlb,rowub,vartypes) = no_mip_solver()
 mixintprog(c::InputVector, A::AbstractMatrix, rowlb::InputVector, rowub::InputVector, vartypes::SymbolInputVector, lb::InputVector, ub::InputVector) = no_mip_solver()
 
 export mixintprog
-
-

--- a/src/HighLevelInterface/quadprog.jl
+++ b/src/HighLevelInterface/quadprog.jl
@@ -1,4 +1,4 @@
-struct QuadprogSolution
+type QuadprogSolution
     status
     objval
     sol

--- a/src/HighLevelInterface/quadprog.jl
+++ b/src/HighLevelInterface/quadprog.jl
@@ -1,5 +1,4 @@
-
-type QuadprogSolution
+struct QuadprogSolution
     status
     objval
     sol

--- a/src/SolverInterface/conic_to_lpqp.jl
+++ b/src/SolverInterface/conic_to_lpqp.jl
@@ -3,7 +3,7 @@
 # To enable LPQP support from a Conic solver, define, e.g.,
 # LinearQuadraticModel(s::ECOSSolver) = ConicToLPQPBridge(ConicModel(s))
 
-type ConicToLPQPBridge <: AbstractLinearQuadraticModel
+mutable struct ConicToLPQPBridge <: AbstractLinearQuadraticModel
     m::AbstractConicModel
     A::SparseMatrixCSC{Float64,Int}
     collb::Vector{Float64}

--- a/src/SolverInterface/lpqp_to_conic.jl
+++ b/src/SolverInterface/lpqp_to_conic.jl
@@ -5,7 +5,7 @@
 # Must also implement supportedcones(). List SOC as a supported cone if it can
 # be passed as a quadratic constraint.
 
-type LPQPtoConicBridge <: AbstractConicModel
+mutable struct LPQPtoConicBridge <: AbstractConicModel
     lpqpmodel::AbstractLinearQuadraticModel
     qcp::Bool
     c
@@ -276,7 +276,7 @@ for f in methods_by_tag[:rewrap]
     @eval $f(model::LPQPtoConicBridge) = $f(model.lpqpmodel)
 end
 
-type LPQPWrapperCallbackData <: MathProgCallbackData
+mutable struct LPQPWrapperCallbackData <: MathProgCallbackData
     lpqpcb::MathProgCallbackData
     model::LPQPtoConicBridge
     solvec::Vector{Float64}

--- a/src/SolverInterface/nonlinear_to_lpqp.jl
+++ b/src/SolverInterface/nonlinear_to_lpqp.jl
@@ -3,7 +3,7 @@
 # To enable LPQP support from a Nonlinear solver, define, e.g.,
 # LinearQuadraticModel(s::IpoptSolver) = NonlinearToLPQPBridge(NonlinearModel(s))
 
-type QuadConstr
+mutable struct QuadConstr
     linearidx::Vector{Int}
     linearval::Vector{Float64}
     quadrowidx::Vector{Int}
@@ -14,7 +14,7 @@ type QuadConstr
 end
 getdata(q::QuadConstr) = q.linearidx, q.linearval, q.quadrowidx, q.quadcolidx, q.quadval
 
-type NonlinearToLPQPBridge <: AbstractLinearQuadraticModel
+mutable struct NonlinearToLPQPBridge <: AbstractLinearQuadraticModel
     nlpmodel::AbstractNonlinearModel
     LPdata
     Qobj::Tuple{Vector{Int},Vector{Int},Vector{Float64}}
@@ -105,7 +105,7 @@ function getquadconstrduals(model::NonlinearToLPQPBridge)
     return du[(numlinconstr(model)+1):end]
 end
 
-type LPQPEvaluator <: AbstractNLPEvaluator
+mutable struct LPQPEvaluator <: AbstractNLPEvaluator
     A::SparseMatrixCSC{Float64,Int}
     c::Vector{Float64}
     Qi::Vector{Int} # quadratic objective terms


### PR DESCRIPTION
Removes warnings on nightly by using `struct` and `mutable struct` instead of `immutable` and `type`.
I have also switched the type for the solutions of the high level interface to immutable type, i.e. `type` -> `struct`.