### PR TITLE
Fix typos and color syntaxing

### DIFF
--- a/src/HighLevelInterface/linprog.jl
+++ b/src/HighLevelInterface/linprog.jl
@@ -197,7 +197,9 @@ A scalar is accepted for the ``l``, ``u``, ``rowlb``, and ``rowub`` arguments, i
 
 A variant usage of this function is to consider the linear programming problem in the following form,
 
-    linprog(c::InputVector, A::AbstractMatrix, sense::InputVector, b::InputVector, lb::InputVector, ub::InputVector, solver::AbstractMathProgSolver)
+```julia
+linprog(c::InputVector, A::AbstractMatrix, sense::InputVector, b::InputVector, lb::InputVector, ub::InputVector, solver::AbstractMathProgSolver)
+```
 
 ```math
 \\begin{align*}
@@ -224,7 +226,9 @@ where:
 
 A shortened version is defined as::
 
-    linprog(c, A, lb, ub, solver) = linprog(c, A, lb, ub, 0, Inf, solver)
+```julia
+linprog(c, A, lb, ub, solver) = linprog(c, A, lb, ub, 0, Inf, solver)
+```
 
 !!! note
     The function [`linprog`](@ref) calls two independent functions for building and solving the linear programming problem, namely [`buildlp`](@ref) and [`solvelp`](@ref).
@@ -232,12 +236,12 @@ A shortened version is defined as::
 The [`linprog`](@ref) function returns an instance of the type::
 
 ```julia
-    type LinprogSolution
-        status
-        objval
-        sol
-        attrs
-    end
+type LinprogSolution
+    status
+    objval
+    sol
+    attrs
+end
 ```
 
 where `status` is a termination status symbol, one of `:Optimal`, `:Infeasible`, `:Unbounded`, `:UserLimit` (iteration limit or timeout), `:Error` (and maybe others).
@@ -256,7 +260,7 @@ If `status` is `:Infeasible`, the `attrs` member will contain an `infeasibilityr
   - `colbasis` -- optimal simplex basis statuses for the variables (columns) if available. Possible values are `:NonbasicAtLower`, `:NonbasicAtUpper`, `:Basic`, and `:Superbasic` (not yet implemented by any solvers)
   - `rowbasis` -- optimal simplex basis statuses for the constraints (rows) if available (not yet implemented by any solvers)
 
-For example, we can solve the two-dimensional problem (see ``test/linprog.jl``):
+For example, we can solve the two-dimensional problem (see `test/linprog.jl`):
 
 ```math
     \\begin{align*}
@@ -267,15 +271,15 @@ For example, we can solve the two-dimensional problem (see ``test/linprog.jl``):
 ```
 
 ```julia
-    using MathProgBase, Clp
+using MathProgBase, Clp
 
-    sol = linprog([-1,0],[2 1],'<',1.5, ClpSolver())
-    if sol.status == :Optimal
-        println("Optimal objective value is \$(sol.objval)")
-        println("Optimal solution vector is: [\$(sol.sol[1]), \$(sol.sol[2])]")
-    else
-        println("Error: solution status \$(sol.status)")
-    end
+sol = linprog([-1,0],[2 1],'<',1.5, ClpSolver())
+if sol.status == :Optimal
+    println("Optimal objective value is \$(sol.objval)")
+    println("Optimal solution vector is: [\$(sol.sol[1]), \$(sol.sol[2])]")
+else
+    println("Error: solution status \$(sol.status)")
+end
 ```
 
 """

--- a/src/HighLevelInterface/mixintprog.jl
+++ b/src/HighLevelInterface/mixintprog.jl
@@ -29,12 +29,14 @@ A scalar is accepted for the ``sense``, ``b``, ``vartypes``, ``lb``, and ``ub`` 
 
 The [`mixintprog`](@ref) function returns an instance of the type::
 
-    type MixintprogSolution
-        status
-        objval
-        sol
-        attrs
-    end
+```julia
+type MixintprogSolution
+    status
+    objval
+    sol
+    attrs
+end
+```
 
 where `status` takes the same values as with [`linprog`](@ref).
 
@@ -61,7 +63,7 @@ We can solve a [binary knapsack problem](http://en.wikipedia.org/wiki/Knapsack_p
 with the following code
 
 ```julia
-    mixintprog(-[5.,3.,2.,7.,4.],[2. 8. 4. 2. 5.],'<',10,:Int,0,1,CbcSolver())
+mixintprog(-[5.,3.,2.,7.,4.],[2. 8. 4. 2. 5.],'<',10,:Int,0,1,CbcSolver())
 ```
 
 """

--- a/src/HighLevelInterface/quadprog.jl
+++ b/src/HighLevelInterface/quadprog.jl
@@ -56,12 +56,14 @@ A scalar is accepted for the ``b``, ``sense``, ``l``, and ``u`` arguments, in wh
 
 The [`quadprog`](@ref) function returns an instance of the type::
 
-    type QuadprogSolution
-        status
-        objval
-        sol
-        attrs
-    end
+```julia
+type QuadprogSolution
+    status
+    objval
+    sol
+    attrs
+end
+```
 
 where `status` is a termination status symbol, one of `:Optimal`, `:Infeasible`, `:Unbounded`, `:UserLimit` (iteration limit or timeout), `:Error` (and maybe others).
 
@@ -84,16 +86,15 @@ We can solve the three-dimensional QP (see `test/quadprog.jl`):
 ```
 
 ```julia
+using MathProgBase, Ipopt
 
-    using MathProgBase, Ipopt
-
-    sol = quadprog([0., 0., 0.],[2. 1. 0.; 1. 2. 1.; 0. 1. 2.],[1. 2. 3.; 1. 1. 0.],'>',[4., 1.],-Inf,Inf, IpoptSolver())
-    if sol.status == :Optimal
-        println("Optimal objective value is \$(sol.objval)")
-        println("Optimal solution vector is: [\$(sol.sol[1]), \$(sol.sol[2]), \$(sol.sol[3])]")
-    else
-        println("Error: solution status \$(sol.status)")
-    end
+sol = quadprog([0., 0., 0.],[2. 1. 0.; 1. 2. 1.; 0. 1. 2.],[1. 2. 3.; 1. 1. 0.],'>',[4., 1.],-Inf,Inf, IpoptSolver())
+if sol.status == :Optimal
+    println("Optimal objective value is \$(sol.objval)")
+    println("Optimal solution vector is: [\$(sol.sol[1]), \$(sol.sol[2]), \$(sol.sol[3])]")
+else
+    println("Error: solution status \$(sol.status)")
+end
 ```
 
 """

--- a/src/SolverInterface/attributes.jl
+++ b/src/SolverInterface/attributes.jl
@@ -13,10 +13,12 @@ Return an attribute of the model `m` specified by attribute type `attr`.
 
 # Examples
 
-    getattribute(m, ObjectiveValue())
-    getattribute(m, VariableResult(), ref)
-    getattribute(m, VariableResult(5), [ref1,ref2])
-    getattribute(m, OtherAttribute("something specific to cplex"))
+```julia
+getattribute(m, ObjectiveValue())
+getattribute(m, VariableResult(), ref)
+getattribute(m, VariableResult(5), [ref1,ref2])
+getattribute(m, OtherAttribute("something specific to cplex"))
+```
 """
 function getattribute end
 

--- a/src/SolverInterface/constraints.jl
+++ b/src/SolverInterface/constraints.jl
@@ -1,8 +1,3 @@
-
-
-
-
-
 """
     addconstraint!(m::AbstractMathProgModel, b, a_constridx, a_varidx, a_coef, Q_constridx, Q_vari, Q_varj, Q_coef, S::AbstractSet)::QuadraticConstraintReference{typeof(S)}
 
@@ -16,7 +11,7 @@ where ``A`` is a sparse matrix specified in triplet form by
 where the symmetric matrix ``Q_k`` is defined by the triplets in `Q_vari`, `Q_varj`,
 `Q_coef` for which `Q_constridx` equals `k`; and the set ``S`` is defined by `S`.
 
-Duplicate indices in either ``A`` or  a ``Q`` matrix are accepted and will be summed together. Off-diagonal entries of ``Q`` will be mirrored, so either the upper triangular or lower triangular entries of ``Q`` should be provided. If entries for both ``(i,j)`` and ``(j,i)`` are provided, these are considered duplicate terms. `a_varidx`, `Q_vari`, `Q_varj` should be collections of `VariableReference` objects.
+Duplicate indices in either the ``A`` or the ``Q`` matrix are accepted and will be summed together. Off-diagonal entries of ``Q`` will be mirrored, so either the upper triangular or lower triangular entries of ``Q`` should be provided. If entries for both ``(i,j)`` and ``(j,i)`` are provided, these are considered duplicate terms. `a_varidx`, `Q_vari`, `Q_varj` should be collections of `VariableReference` objects.
 
 
 
@@ -71,7 +66,7 @@ function addconstraint! end
 Modify elements of the `i`'th row of the constraint `c` depending on the
 arguments `args`. The `i`'th row will have the form
 ```math
-    a_i^T + b_i + \\frac{1}{2}x^TQ_ix \\in S
+    a_i^Tx + b_i + \\frac{1}{2}x^TQ_ix \\in S
 ```
 There are three cases.
 
@@ -83,11 +78,13 @@ Set the constant term of the `i`'th row in the constraint `c` to `b`.
 
 ### Examples
 
-        modifyconstraint!(m, c, 1, 1.0)
+```julia
+modifyconstraint!(m, c, 1, 1.0)
+```
 
 # Modify Linear term
 
-modifyconstraint!(m::AbstractMathProgModel, c::ConstraintReference, i::Int, a_varidx, a_coef)
+    modifyconstraint!(m::AbstractMathProgModel, c::ConstraintReference, i::Int, a_varidx, a_coef)
 
 Set elements given by `a_varidx` in the linear term of the `i`'th element in the
 constraint `c` to `a_coef`. Either `a_varidx` and `a_coef` are both singletons,
@@ -97,8 +94,10 @@ The behaviour of duplicate entries in `a_varidx` is undefined.
 
 ### Examples
 
-        modifyconstraint!(m, c, v, 1.0)
-        modifyconstraint!(m, c, [v1, v2], [1.0, 2.0])
+```julia
+modifyconstraint!(m, c, v, 1.0)
+modifyconstraint!(m, c, [v1, v2], [1.0, 2.0])
+```
 
 # Modify Quadratic term
 
@@ -114,8 +113,10 @@ and ``(j,i)`` are provided, these are considered duplicate terms.
 
 ### Examples
 
-        modifyconstraint!(m, c, v1, v2, 1.0)
-        modifyconstraint!(m, c, [v1, v2], [v1, v1], [1.0, 2.0])
+```julia
+modifyconstraint!(m, c, v1, v2, 1.0)
+modifyconstraint!(m, c, [v1, v2], [v1, v1], [1.0, 2.0])
+```
 
 # Modify Set
 
@@ -128,7 +129,9 @@ type as the original set.
 
 If `c` is a `ConstraintReference{Interval}`
 
-        modifyconstraint!(m, c, Interval(0, 5))
-        modifyconstraint!(m, c, NonPositive) # errors
+```julia
+modifyconstraint!(m, c, Interval(0, 5))
+modifyconstraint!(m, c, NonPositive) # errors
+```
 """
 function modifyconstraint! end

--- a/src/SolverInterface/nlp.jl
+++ b/src/SolverInterface/nlp.jl
@@ -182,7 +182,7 @@ function obj_expr end
 """
     constr_expr(d::AbstractNLPEvaluator, i)
 
-Returns an expression graph for the ``i\\text{th}`` constraint in the same format as described above. The head of the expression is ``:comparison``, indicating the sense
+Returns an expression graph for the ``i^{\\text{th}}`` constraint in the same format as described above. The head of the expression is ``:comparison``, indicating the sense
 of the constraint. The right-hand side of the comparison must be a constant; that is,
 `:(x[1]^3 <= 1)` is allowed, while `:(1 <= x[1]^3)` is not valid.
 Double-sided constraints are allowed, in which case both the lower bound and
@@ -212,9 +212,6 @@ isobjquadratic(::AbstractNLPEvaluator) = false
 """
     isconstrlinear(::AbstractNLPEvaluator, i::Integer)
 
-`true` if the ``i\text{th}`` constraint is known to be linear, `false` otherwise.
+`true` if the ``i^{\\text{th}}`` constraint is known to be linear, `false` otherwise.
 """
 isconstrlinear(::AbstractNLPEvaluator, i::Integer) = false
-
-
-

--- a/src/SolverInterface/objectives.jl
+++ b/src/SolverInterface/objectives.jl
@@ -9,7 +9,7 @@ where ``a`` is a sparse vector specified in tuple form by `a_varidx`, and
 `a_coef`; ``b`` is a scalar; and the symmetric matrix ``Q`` is defined by the
 triplets in `Q_vari`, `Q_varj`, `Q_coef`.
 
-Duplicate indices in either ``A`` or  a ``Q`` matrix are accepted and will be
+Duplicate indices in either the ``a`` vector or the ``Q`` matrix are accepted and will be
 summed together. Off-diagonal entries of ``Q`` will be mirrored, so either the
 upper triangular or lower triangular entries of ``Q`` should be provided. If
 entries for both ``(i,j)`` and ``(j,i)`` are provided, these are considered
@@ -36,7 +36,9 @@ Set the constant term of the `i`'th row objective to `b`.
 
 ### Examples
 
-        modifyobjective!(m, 1, 1.0)
+```julia
+modifyobjective!(m, 1, 1.0)
+```
 
 # Modify Linear term
 
@@ -50,8 +52,10 @@ The behaviour of duplicate entries in `a_varidx` is undefined.
 
 ### Examples
 
-        modifyobjective!(m, 1, v, 1.0)
-        modifyobjective!(m, 1, [v1, v2], [1.0, 2.0])
+```julia
+modifyobjective!(m, 1, v, 1.0)
+modifyobjective!(m, 1, [v1, v2], [1.0, 2.0])
+```
 
 # Modify Quadratic term
 
@@ -66,8 +70,10 @@ and ``(j,i)`` are provided, these are considered duplicate terms.
 
 ### Examples
 
-        modifyobjective!(m, 1, v1, v2, 1.0)
-        modifyobjective!(m, 1, [v1, v2], [v1, v1], [1.0, 2.0])
+```julia
+modifyobjective!(m, 1, v1, v2, 1.0)
+modifyobjective!(m, 1, [v1, v2], [v1, v1], [1.0, 2.0])
+```
 """
 function modifyobjective! end
 

--- a/src/SolverInterface/references.jl
+++ b/src/SolverInterface/references.jl
@@ -1,5 +1,3 @@
-
-
 """
     VariablewiseConstraintReference{T}
 

--- a/src/SolverInterface/sets.jl
+++ b/src/SolverInterface/sets.jl
@@ -1,5 +1,3 @@
-
-
 """
     AbstractSet
 

--- a/src/SolverInterface/variables.jl
+++ b/src/SolverInterface/variables.jl
@@ -1,5 +1,3 @@
-
-
 """
     addvariables!(m::AbstractMathProgModel, N::Int)
 
@@ -11,7 +9,6 @@ function addvariables! end
 """
     addvariable!(m::AbstractMathProgModel, N::Int)
 
-Add a scalar variable to the model, returning a vector of variable
-references.
+Add a scalar variable to the model, returning variable reference.
 """
 function addvariable! end


### PR DESCRIPTION
I have not changed the method signatures yet from 4-spaces indenting to ` ```julia ... ``` ` but I would be in favor of doing so since it gives syntax highlighting of e.g. `AbstractMatrix`. What do you think ?