### PR TITLE
Base.Test -> Compat.Test

### DIFF
--- a/test/nlp.jl
+++ b/test/nlp.jl
@@ -1,6 +1,6 @@
-using Base.Test
 using MathProgBase
 using Compat
+using Compat.Test
 
 # Here the type represents the complete instance, but it
 # could also store instance data.


### PR DESCRIPTION
I just noticed this 0.7 deprecation when updating NLopt.jl, which uses this file.