### PR TITLE
Extend support of LinearQuadratic interface in NonlinearToLPQPBridge.

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using GLPKMathProgInterface, Ipopt, ECOS
 lp_solver = GLPKSolverLP()
 ip_solver = GLPKSolverMIP()
 conic_solver = ECOSSolver(verbose=false)
-nlp_solver = IpoptSolver(print_level=0)
+nlp_solver = IpoptSolver(print_level=0, fixed_variable_treatment="make_constraint")
 
 include("linprog.jl")
 linprogtest(lp_solver)
@@ -32,3 +32,5 @@ linprogsolvertest(lp_solver)
 linprogsolvertestextra(lp_solver)
 # Test LP fallback for conics
 linprogsolvertest(conic_solver)
+# Test LP fallback for nlp
+linprogsolvertest(nlp_solver, 1e-5)


### PR DESCRIPTION
I had a use case for setobj!, addconstr!, addvar!, delconstrs! when solving a quadratic program with Ipopt, which was not supported in the NonlinearToLPQPBridge. This adds support for most of the LinearQuadratic interface functions in the NonlinearToLPQPBridge and should be functional with Ipopt at least. I have my fork as a test dependency at the moment, but I thought this could be useful for others as well.

I Added a linprogsolvertest of IpoptSolver, with absolute tolerance 1e-5 as in nlp tests (I had to pass fixed_variable_treatment="make_constraint" to Ipopt to get correct reduced costs in the fixed variable case).

Passes all tests locally.